### PR TITLE
change coeffs to coefficients

### DIFF
--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -18,7 +18,7 @@ function convert_ff_singular_ideal_to_array(
     cc = 1 # coefficient counter
     ec = 0 # exponent vector counter
     for i = 1:Singular.ngens(id)
-        for c in Singular.coeffs(id[i])
+        for c in Singular.coefficients(id[i])
             cfs[cc] = Base.Int(c)
             cc += 1
         end
@@ -44,7 +44,7 @@ function convert_ff_singular_ideal_to_signature_basis(
         basis.monomials[i]    = Array{SVector{N, exp_t}}(undef, basis.numberTerms[i])
         cc  = 1
         ec  = 1
-        for c in Singular.coeffs(id[i])
+        for c in Singular.coefficients(id[i])
             basis.coefficients[i][cc] = cf_t(Int(c))
             cc += 1
         end
@@ -91,7 +91,7 @@ function convert_qq_singular_ideal_to_array(
     cc = 1 # coefficient counter
     ec = 0 # exponent vector counter
     for i = 1:Singular.ngens(id)
-        for c in Singular.coeffs(id[i])
+        for c in Singular.coefficients(id[i])
             cfs[cc] = Singular.libSingular.n_GetMPZ(numerator(c).ptr, Singular.ZZ.ptr)
             cc += 1
             cfs[cc] = Singular.libSingular.n_GetMPZ(denominator(c).ptr, Singular.ZZ.ptr)


### PR DESCRIPTION
Hi !
I am getting the following warning when calling f4 over finite and rational fields. Suggest a change of _coeffs_ to _coefficients_.

```
┌ Warning: coeffs(a::AbstractAlgebra.MPolyElem{T}) where T <: RingElement is deprecated, use coefficients(a) instead.
│   caller = convert_qq_singular_ideal_to_array(::Singular.sideal{Singular.spoly{Singular.n_Q}}, ::Int64, ::Int64) at Interfaces.jl:94
└ @ Main.GroebnerBasis /media/sf_shared/GroebnerBasis.jl/src/Interfaces.jl:94
```